### PR TITLE
Fixed regexp for directives pattern

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -32,7 +32,7 @@ Resource.HEADER_PATTERN = new RegExp(
     '(?:#.*\n?)+' +
   ')*' +
 ')*', 'm');
-Resource.DIRECTIVE_PATTERN = /^\W*=\s*(\w+.*?)(\*\/)?$/;
+Resource.DIRECTIVE_PATTERN = /^\s*=\s*?((?:require|include|require_directory|require_tree|require_self|stub)\s\w.*)$/
 Resource.TYPE_PATTERN      = /(\w+)(?:\s+(["']?)(.*)\2)?/;
 
 // Define methods.


### PR DESCRIPTION
Previous regexp matched javascript strings, like this:

```
) !== false) && that._onSend(e, this);
```

 and resulting file sometimes appears to be broken.

Example project: https://www.dropbox.com/s/350qtn07phy5u26/sprockets_bug.zip?dl=0
