### PR TITLE
Fixed regexp for directives pattern

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -32,7 +32,7 @@ Resource.HEADER_PATTERN = new RegExp(
     '(?:#.*\n?)+' +
   ')*' +
 ')*', 'm');
-Resource.DIRECTIVE_PATTERN = /^\s*=\s*?((?:require|include|require_directory|require_tree|require_self|stub)\s\w.*)$/
+Resource.DIRECTIVE_PATTERN = /^\/?\/?\s*=\s*((?:require|include|require_directory|require_tree|require_self|stub)\s?\w?.*)$/
 Resource.TYPE_PATTERN      = /(\w+)(?:\s+(["']?)(.*)\2)?/;
 
 // Define methods.

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -32,7 +32,7 @@ Resource.HEADER_PATTERN = new RegExp(
     '(?:#.*\n?)+' +
   ')*' +
 ')*', 'm');
-Resource.DIRECTIVE_PATTERN = /^\W*=\s*(\w+.*?)(\*\/)?$/;
+Resource.DIRECTIVE_PATTERN = /^\s*=\s*?((?:require|include|require_directory|require_tree|require_self|stub)\s\w.*)$/
 Resource.TYPE_PATTERN      = /(\w+)(?:\s+(["']?)(.*)\2)?/;
 
 // Define methods.

--- a/test/expected/out.js
+++ b/test/expected/out.js
@@ -5,6 +5,23 @@ var name = 'qux';
 
 var name = 'foo';
 
+submit = function () {
+    if (this.state() !== 'pending') {
+        data.jqXHR = this.jqXHR =
+            (that._trigger(
+                'submit',
+                $.Event('submit', {delegatedEvent: e}),
+                this
+            ) !== false) && that._onSend(e, this);
+    }
+    return this.jqXHR || that._getXHRPromise();
+};
+
+var zoo = 'zoo';
 
 
+/*
+
+
+*/
 var name = 'main';

--- a/test/fixtures/foo.js
+++ b/test/fixtures/foo.js
@@ -1,3 +1,15 @@
 //= include bar
 
 var name = 'foo';
+
+submit = function () {
+    if (this.state() !== 'pending') {
+        data.jqXHR = this.jqXHR =
+            (that._trigger(
+                'submit',
+                $.Event('submit', {delegatedEvent: e}),
+                this
+            ) !== false) && that._onSend(e, this);
+    }
+    return this.jqXHR || that._getXHRPromise();
+};

--- a/test/fixtures/main.js
+++ b/test/fixtures/main.js
@@ -1,4 +1,6 @@
 //= require_directory baz
-//= require foo
-
+/*
+=require foo
+= require ../fixtures/zoo/zoo
+*/
 var name = 'main';

--- a/test/fixtures/zoo/zoo.js
+++ b/test/fixtures/zoo/zoo.js
@@ -1,0 +1,1 @@
+var zoo = 'zoo';


### PR DESCRIPTION
Same comment as previous PR:

Previous regexp matched javascript strings, like this:

```
) !== false) && that._onSend(e, this);
```

 and resulting file sometimes appears to be broken.

Example project: https://www.dropbox.com/s/350qtn07phy5u26/sprockets_bug.zip?dl=0

This time fixed relative paths and updated tests.
