### PR TITLE
update grunt-contrib-concat dependency for sourceMap support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main"            : "tasks/directives.js",
   "scripts"         : {  "test": "grunt test" },
-  "dependencies"    : { "grunt-contrib-concat": "~0.3" },
+  "dependencies"    : { "grunt-contrib-concat": "~0.5" },
   "devDependencies" : {
     "grunt"                  : "~0.4",
     "grunt-contrib-clean"    : "~0.5",

--- a/tasks/directives.js
+++ b/tasks/directives.js
@@ -9,9 +9,7 @@ module.exports = function(grunt) {
 
   // Load tasks. Avoid using `grunt.loadNpmTasks` as this will try to load the
   // module relative to the projects `Gruntfile.js`.
-  var modulePath = path.dirname(require.resolve('grunt-contrib-concat'));
-  var taskPath   = path.join(modulePath, 'tasks');
-  grunt.loadTasks(taskPath);
+  var taskPath = path.join(__dirname, '..', 'node_modules', 'grunt-contrib-concat', 'tasks');  grunt.loadTasks(taskPath);
 
   // Register directives task.
   grunt.registerMultiTask('directives', description, function() {


### PR DESCRIPTION
Hi,

What it says: the version of grunt-contrib-concat referenced was too old to generate sourcemaps, this updates it.

For some reason once this was updated the method used to load the tasks no longer worked so we have to refer to them by path traversal.
